### PR TITLE
Add a missing require

### DIFF
--- a/lib/fishwife/rack_servlet.rb
+++ b/lib/fishwife/rack_servlet.rb
@@ -16,6 +16,7 @@
 #++
 
 require 'tempfile'
+require 'stringio'
 
 # Magic loader hook -> JRubyService
 require 'fishwife/JRuby'


### PR DESCRIPTION
Fishwife doesn't seem to load StringIO before it is used. If my code doesn't load it I get only error 500 and "uninitialized constant Fishwife::RackServlet::StringIO".

A minimal example to reproduce:

``` ruby
require 'fishwife'
server = Fishwife::HttpServer.new(:Port => 3210)
server.start(lambda { [200, {}, []] })
```
