### PR TITLE
Don't mutate the Rack response

### DIFF
--- a/lib/fishwife/rack_servlet.rb
+++ b/lib/fishwife/rack_servlet.rb
@@ -255,17 +255,18 @@ module Fishwife
         # Set the HTTP status code.
         response.setStatus(status.to_i)
 
-        # Did we get a Content-Length header?
-        content_length = headers.delete('Content-Length')
-        response.setContentLength(content_length.to_i) if content_length
-
-        # Did we get a Content-Type header?
-        content_type = headers.delete('Content-Type')
-        response.setContentType(content_type) if content_type
-
         # Add all the result headers.
         headers.each do |h, v|
-          v.split("\n").each { |val| response.addHeader(h, val) }
+          case h
+          when 'Content-Length'
+            # Did we get a Content-Length header?
+            response.setContentLength(v.to_i) if v
+          when 'Content-Type'
+            # Did we get a Content-Type header?
+            response.setContentType(v) if v
+          else
+            v.split("\n").each { |val| response.addHeader(h, val) }
+          end
         end
       end
 
@@ -276,7 +277,9 @@ module Fishwife
         path = body.to_path
 
         # Set Content-Length unless this is an async request.
-        response.setContentLength( File.size( path ) ) unless content_length
+        unless headers['Content-Length']
+          response.setContentLength( File.size( path ) )
+        end
 
         # FIXME: Support ranges?
 

--- a/spec/fishwife_spec.rb
+++ b/spec/fishwife_spec.rb
@@ -254,6 +254,11 @@ describe Fishwife do
         lock.synchronize { buffer.count.should == 10 }
       end
 
+      it "handles frozen Rack responses" do
+        response = get("/frozen_response")
+        response.code.should == "200"
+      end
+
     end
 
   end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -126,4 +126,8 @@ class TestApp
     response.write(checksum)
     response.finish
   end
+
+  def frozen_response(request)
+    [200, {}.freeze, [].freeze].freeze
+  end
 end


### PR DESCRIPTION
Fishwife mutates the headers component of the Rack response, which means that a Rack app can't return a frozen object. It might also cause strange bugs in Rack applications that reuse the same hash header for multiple requests.

See for example https://github.com/iconara/regal/pull/1
