### PR TITLE
Hijack support

### DIFF
--- a/lib/fishwife.rb
+++ b/lib/fishwife.rb
@@ -32,4 +32,5 @@ end
 require 'rack'
 require 'fishwife/rack_servlet'
 require 'fishwife/http_server'
+require 'fishwife/hijack_io'
 require 'rack/handler/fishwife'

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -2,26 +2,28 @@ module Fishwife
   class HijackIo
     def initialize(async_context)
       @async_context = async_context
+      @closed = false
     end
 
     def write(str)
       IOUtil.write(str, @async_context.response.output_stream)
+      str.bytesize
     end
 
     def flush
       @async_context.response.output_stream.flush
+      self
     end
 
     def close
       @async_context.complete
+      @closed = true
+      nil
     end
-
-    def close_write(str)
-      write(str)
-      close
-    end
+    alias_method :close_write, :close
 
     def closed?
+      @closed
     end
 
     def read(*)

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -9,7 +9,7 @@ module Fishwife
     end
 
     def flush
-      @async_context.response.writer.flush
+      @async_context.response.output_stream.flush
     end
 
     def close

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -25,19 +25,19 @@ module Fishwife
     end
 
     def read(*)
-      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+      raise NotImplementedError, "##{__method__} on hijacked IO is not supported"
     end
 
     def read_nonblock(*)
-      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+      raise NotImplementedError, "##{__method__} on hijacked IO is not supported"
     end
 
     def write_nonblock(*)
-      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+      raise NotImplementedError, "##{__method__} on hijacked IO is not supported"
     end
 
     def close_read
-      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+      raise NotImplementedError, "##{__method__} on hijacked IO is not supported"
     end
   end
 end

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -5,7 +5,7 @@ module Fishwife
     end
 
     def write(str)
-      @async_context.response.output_stream.write(str.to_java_bytes)
+      IOUtil.write(str, @async_context.response.output_stream)
     end
 
     def flush

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -5,7 +5,7 @@ module Fishwife
     end
 
     def write(str)
-      @async_context.response.output_stream.print(str)
+      @async_context.response.output_stream.write(str.to_java_bytes)
     end
 
     def flush

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -1,0 +1,52 @@
+module Fishwife
+  class HijackIo
+    class WriteWouldBlock < Errno::EWOULDBLOCK
+      include IO::WaitWritable
+    end
+
+    def initialize(async_context)
+      @async_context = async_context
+    end
+
+    def write(str)
+      @async_context.response.output_stream.print(str)
+    end
+
+    def write_nonblock(str)
+      output_stream = @async_context.response.output_stream
+      if output_stream.ready?
+        output_stream.print(str)
+      else
+        raise WriteWouldBlock
+      end
+    end
+
+    def flush
+      @async_context.response.writer.flush
+    end
+
+    def close
+      @async_context.complete
+    end
+
+    def close_write(str)
+      write(str)
+      close
+    end
+
+    def closed?
+    end
+
+    def read(*)
+      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+    end
+
+    def read_nonblock(*)
+      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+    end
+
+    def close_read
+      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+    end
+  end
+end

--- a/lib/fishwife/hijack_io.rb
+++ b/lib/fishwife/hijack_io.rb
@@ -1,24 +1,11 @@
 module Fishwife
   class HijackIo
-    class WriteWouldBlock < Errno::EWOULDBLOCK
-      include IO::WaitWritable
-    end
-
     def initialize(async_context)
       @async_context = async_context
     end
 
     def write(str)
       @async_context.response.output_stream.print(str)
-    end
-
-    def write_nonblock(str)
-      output_stream = @async_context.response.output_stream
-      if output_stream.ready?
-        output_stream.print(str)
-      else
-        raise WriteWouldBlock
-      end
     end
 
     def flush
@@ -42,6 +29,10 @@ module Fishwife
     end
 
     def read_nonblock(*)
+      raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
+    end
+
+    def write_nonblock(*)
       raise NotImplementedError, '##{__method__} on hijacked IO is not supported'
     end
 

--- a/spec/fishwife/hijack_io_spec.rb
+++ b/spec/fishwife/hijack_io_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe Fishwife::HijackIo do
+  subject :io do
+    described_class.new(async_context)
+  end
+
+  let :async_context do
+    double(:async_context)
+  end
+
+  let :buffer do
+    StringIO.new
+  end
+
+  let :output_stream do
+    buffer.to_outputstream
+  end
+
+  before do
+    response = double(:response)
+    async_context.stub(:response).and_return(response)
+    async_context.stub(:complete)
+    response.stub(:output_stream).and_return(output_stream)
+  end
+
+  describe '#write' do
+    it 'writes a string to the response output stream' do
+      io.write('hello')
+      buffer.string.should eq('hello')
+    end
+
+    it 'returns the number of bytes written' do
+      io.write('hello').should eq(5)
+      io.write("\u2603").should eq(3)
+    end
+  end
+
+  describe '#flush' do
+    let :output_stream do
+      double(:output_stream)
+    end
+
+    before do
+      output_stream.stub(:flush)
+    end
+
+    it 'flushes the response output stream' do
+      output_stream.should_receive(:flush)
+      io.flush
+    end
+
+    it 'returns self' do
+      io.flush.should equal(io)
+    end
+  end
+
+  [:close, :close_write].each do |method_name|
+    describe "##{method_name}" do
+      before do
+        async_context.stub(:complete)
+      end
+
+      it 'completes the async processing' do
+        async_context.should_receive(:complete)
+        io.send(method_name)
+      end
+
+      it 'returns nil' do
+        io.send(method_name).should be_nil
+      end
+    end
+  end
+
+  describe '#closed?' do
+    context 'before #close has been called' do
+      it 'returns false' do
+        io.should_not be_closed
+      end
+    end
+
+    context 'after #close has been called' do
+      it 'returns true' do
+        io.close
+        io.should be_closed
+      end
+    end
+  end
+end

--- a/spec/fishwife_spec.rb
+++ b/spec/fishwife_spec.rb
@@ -232,31 +232,18 @@ describe Fishwife do
         response.body.should == '8da4b60a9bbe205d4d3699985470627e'
       end
 
-      it "handles async requests" do
-        pending "Causes intermittent 30s pauses, TestApp.push/pull is sketchy"
-        lock = Mutex.new
-        buffer = Array.new
-
-        clients = 10.times.map do |index|
-          Thread.new do
-            Net::HTTP.start(@options[:host], @options[:port]) do |http|
-              response = http.get("/pull")
-              lock.synchronize {
-                buffer << "#{index}: #{response.body}" }
-            end
-          end
-        end
-
-        lock.synchronize { buffer.should be_empty }
-        post("/push", 'message' => "one")
-        clients.each { |c| c.join }
-        lock.synchronize { buffer.should_not be_empty }
-        lock.synchronize { buffer.count.should == 10 }
-      end
-
       it "handles frozen Rack responses" do
         response = get("/frozen_response")
         response.code.should == "200"
+      end
+
+      it "handles request hijacking" do
+        read_thread = Thread.start do
+          get("/hijack")
+        end
+        response = read_thread.value
+        response.code.should eq('200')
+        response.body.should eq('hello world')
       end
 
     end

--- a/spec/fishwife_spec.rb
+++ b/spec/fishwife_spec.rb
@@ -237,13 +237,10 @@ describe Fishwife do
         response.code.should == "200"
       end
 
-      it "handles request hijacking" do
-        read_thread = Thread.start do
-          get("/hijack")
-        end
-        response = read_thread.value
+      it "handles response hijacking" do
+        response = get("/hijack")
         response.code.should eq('200')
-        response.body.should eq('hello world')
+        response.body.should eq("hello world\n")
       end
 
     end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -28,10 +28,6 @@ require 'json'
 #
 # /file:: Returns a file for downloading.
 #
-# /push:: Publishes a message to async listeners.
-#
-# /pull:: Recieves messages sent via /push using async.
-#
 # A request to any endpoint not listed above will return a 404 error.
 class TestApp
   def initialize
@@ -84,33 +80,6 @@ class TestApp
     [ 204, { "Warning" => %w[ warn-1 warn-2 ].join( "\n" ) }, [] ]
   end
 
-  def push(request)
-    message = request.params['message']
-
-    @subscribers.reject! do |subscriber|
-      begin
-        response = Rack::Response.new
-        if(message.empty?)
-          subscriber.call(response.finish)
-          next(true)
-        else
-          response.write(message)
-          subscriber.call(response.finish)
-          next(false)
-        end
-      rescue java.io.IOException => error
-        next(true)
-      end
-    end
-
-    ping(request)
-  end
-
-  def pull(request)
-    @subscribers << request.env['async.callback']
-    throw(:async)
-  end
-
   def download(request)
     file = File.new( File.dirname( __FILE__ ) + "/data/reddit-icon.png" )
     def file.to_path
@@ -129,5 +98,22 @@ class TestApp
 
   def frozen_response(request)
     [200, {}.freeze, [].freeze].freeze
+  end
+
+  def hijack(request)
+    if request.env['rack.hijack?']
+      request.env['rack.hijack'].call
+      io = request.env['rack.hijack_io']
+      Thread.start do
+        io.write("hello ")
+        sleep(1)
+        io.write("world\n")
+        sleep(1)
+        io.close
+      end
+      [-1, {}, []]
+    else
+      [501, {}, []]
+    end
   end
 end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -102,18 +102,19 @@ class TestApp
 
   def hijack(request)
     if request.env['rack.hijack?']
-      request.env['rack.hijack'].call
-      io = request.env['rack.hijack_io']
-      Thread.start do
-        io.write("hello ")
-        sleep(1)
-        io.write("world\n")
-        sleep(1)
-        io.close
-      end
-      [-1, {}, []]
+      [200, {'rack.hijack' => method(:hijack_response)}, []]
     else
-      [501, {}, []]
+      [501, {}, ['Hijack not supported']]
+    end
+  end
+
+  private
+
+  def hijack_response(io)
+    Thread.start do
+      io.write("hello ")
+      io.write("world\n")
+      io.close
     end
   end
 end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -113,6 +113,7 @@ class TestApp
   def hijack_response(io)
     Thread.start do
       io.write("hello ")
+      io.flush
       io.write("world\n")
       io.close
     end

--- a/src/main/java/fishwife/IOUtil.java
+++ b/src/main/java/fishwife/IOUtil.java
@@ -83,6 +83,33 @@ public class IOUtil
         }
     }
 
+    @JRubyMethod( name = "write",
+                  meta = true,
+                  required = 2,
+                  argTypes = { RubyObject.class,
+                               OutputStream.class } )
+    public static IRubyObject write( ThreadContext tc,
+                                     IRubyObject klazz,
+                                     IRubyObject data,
+                                     IRubyObject out )
+    {
+        OutputStream ostream = (OutputStream) out.toJava( OutputStream.class );
+
+        try {
+            final RubyString str = data.convertToString();
+            final ByteList blist = str.getByteList();
+
+            ostream.write( blist.unsafeBytes(),
+                           blist.begin(),
+                           blist.length() );
+
+            return tc.getRuntime().getNil();
+        }
+        catch( IOException x ) {
+            throw createNativeRaiseException( tc.getRuntime(), x );
+        }
+    }
+
     @JRubyMethod( name = "write_body",
                   meta = true,
                   required = 2,

--- a/src/main/java/fishwife/IOUtil.java
+++ b/src/main/java/fishwife/IOUtil.java
@@ -95,19 +95,9 @@ public class IOUtil
     {
         OutputStream ostream = (OutputStream) out.toJava( OutputStream.class );
 
-        try {
-            final RubyString str = data.convertToString();
-            final ByteList blist = str.getByteList();
+        writeToOutputStream(data.convertToString(), ostream);
 
-            ostream.write( blist.unsafeBytes(),
-                           blist.begin(),
-                           blist.length() );
-
-            return tc.getRuntime().getNil();
-        }
-        catch( IOException x ) {
-            throw createNativeRaiseException( tc.getRuntime(), x );
-        }
+        return tc.getRuntime().getNil();
     }
 
     @JRubyMethod( name = "write_body",
@@ -133,6 +123,17 @@ public class IOUtil
         return tc.getRuntime().getNil();
     }
 
+    private static void writeToOutputStream(RubyString str, OutputStream out) {
+      final ByteList blist = str.getByteList();
+
+      try {
+          out.write( blist.unsafeBytes(), blist.begin(), blist.length() );
+      }
+      catch( IOException x ) {
+          throw createNativeRaiseException( str.getRuntime(), x );
+      }
+    }
+
     public static final class AppendBlockCallback implements BlockCallback
     {
         public AppendBlockCallback(Ruby runtime, OutputStream out)
@@ -145,19 +146,9 @@ public class IOUtil
                                  IRubyObject[] args,
                                  Block blk )
         {
-            try {
-                final RubyString str = args[0].convertToString();
-                final ByteList blist = str.getByteList();
+            writeToOutputStream(args[0].convertToString(), _out);
 
-                _out.write( blist.unsafeBytes(),
-                            blist.begin(),
-                            blist.length() );
-
-                return _runtime.getNil();
-            }
-            catch( IOException x ) {
-                throw createNativeRaiseException( _runtime, x );
-            }
+            return _runtime.getNil();
         }
 
         private final Ruby _runtime;


### PR DESCRIPTION
This is an attempt at implementing (partial) `rack.hijack` support, as a follow up to #15. It removes support for `async.callback`, since it doesn't seem to work in Fishwife currently, and it also seems like it was abandoned in Rack in favour of `rack.hijack`.

Fishwife will probably not support all of the `rack.hijack` spec, it doesn't look like it's possible to get hold of the raw output stream without Jetty writing the HTTP header.