### PR TITLE
Travis CI matrix: JRuby 9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 before_install: "gem install rjack-tarpit -v=2.1.2"
 install: "bundle install --jobs=3 --retry=3"
 sudo: false
-script: "bundle exec rake test"
 dist: trusty
 matrix:
   include:
@@ -10,12 +9,12 @@ matrix:
       jdk: openjdk7
       gemfile: Gemfile.92
       dist: precise
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.15.0
       jdk: oraclejdk8
       gemfile: Gemfile.93
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.15.0
       jdk: oraclejdk8
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.15.0
       jdk: openjdk8
     - rvm: jruby-head
       jdk: oraclejdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest-released JRuby.

- JRuby 9.1.15.0
- Simplify the Travis YAML by using the `bundle exec rake` default `script` step