### PR TITLE
Travis CI: jruby-9.1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
       jdk: openjdk7
       gemfile: Gemfile.92
       dist: precise
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.16.0
       jdk: oraclejdk8
       gemfile: Gemfile.93
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.16.0
       jdk: oraclejdk8
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.16.0
       jdk: openjdk8
     - rvm: jruby-head
       jdk: oraclejdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/02/21/jruby-9-1-16-0.html