### PR TITLE
CI: Include JRuby 9.2.6.0 on openjdk-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ install: "bundle _1.17.3_ install --jobs=3 --retry=3"
 dist: trusty
 matrix:
   include:
+    - rvm: jruby-9.2.6.0
+      jdk: openjdk8
     - rvm: jruby-9.1.17.0
       jdk: oraclejdk8
       gemfile: Gemfile.93


### PR DESCRIPTION
This PR extends the CI matrix with the latest release of JRuby.

