### PR TITLE
Upgrade/broaden to rack [1.6.4,3.0)

### DIFF
--- a/Gemfile.93.lock
+++ b/Gemfile.93.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    fishwife (1.10.0-java)
-      rack (>= 1.6.4, < 2.1)
+    fishwife (1.10.1-java)
+      rack (>= 1.6.4, < 3.0)
       rjack-jetty (>= 9.2.11, < 9.5)
       rjack-slf4j (~> 1.7.2)
 
@@ -11,7 +11,7 @@ GEM
   specs:
     diff-lcs (1.3)
     json (2.1.0-java)
-    rack (2.0.5)
+    rack (2.2.3)
     rake (12.1.0)
     rdoc (4.3.0)
     rjack-jetty (9.3.19.0-java)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fishwife (1.10.1-java)
-      rack (>= 1.6.4, < 2.1)
+      rack (>= 1.6.4, < 3.0)
       rjack-jetty (>= 9.2.11, < 9.5)
       rjack-slf4j (~> 1.7.2)
 
@@ -11,7 +11,7 @@ GEM
   specs:
     diff-lcs (1.3)
     json (2.1.0-java)
-    rack (2.0.6)
+    rack (2.2.3)
     rake (12.3.2)
     rdoc (4.3.0)
     rjack-jetty (9.4.20.0-java)

--- a/fishwife.gemspec
+++ b/fishwife.gemspec
@@ -11,7 +11,7 @@ RJack::TarPit.specify do |s|
 
   s.add_developer( 'David Kellum', 'dek-oss@gravitext.com' )
 
-  s.depend 'rack',                  '>= 1.6.4', '< 2.1'
+  s.depend 'rack',                  '>= 1.6.4', '< 3.0'
   s.depend 'rjack-jetty',           '>= 9.2.11', '< 9.5'
   s.depend 'rjack-slf4j',           '~> 1.7.2'
 


### PR DESCRIPTION
**Update to broaden to rack requirement to [1.6.4,3.0)**

I believe that Rack is now using SemVer (based on addition of "SemVer stability" badge), so would it make sense to clamp on major version now rather than minor?